### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ This is how it works:
 * At least two operands and one operator are needed to have a valid operation.
 * Negative numbers are allowed. e.g. "-6_3/4" or "-7" or "-4/5"
 * The result will also be represented as a fraction, unless it is whole.
+
+[![Run on Repl.it](https://repl.it/badge/github/calavraian/FractionCalculator)](https://repl.it/github/calavraian/FractionCalculator)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@calavraian/FractionCalculator).